### PR TITLE
Remove 1 unnecessary stubbing in ThingManagerTest.java

### DIFF
--- a/src/test/java/com/garbagemule/MobArena/things/ThingManagerTest.java
+++ b/src/test/java/com/garbagemule/MobArena/things/ThingManagerTest.java
@@ -61,7 +61,6 @@ public class ThingManagerTest {
         ThingParser third = mock(ThingParser.class);
         when(first.parse("thing")).thenReturn(null);
         when(second.parse("thing")).thenReturn(thing);
-        when(third.parse("thing")).thenReturn(thing);
         subject.register(first);
         subject.register(second);
         subject.register(third);


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [X] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Removed  1 unnecessary stubbing from `ThingManagerTest.firstNonNullThingIsReturned`

# Problem
Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_):


# Solution
The stubbing is not executed by the test `firstNonNullThingIsReturned` in the `ThingManagerTest.java`, therefore we should remove it.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->

