### PR TITLE
Remove 1 unnecessary stubbing in MoneyThingPraserTest.java

### DIFF
--- a/src/test/java/com/garbagemule/MobArena/things/SecondMoneyThingParserTest.java
+++ b/src/test/java/com/garbagemule/MobArena/things/SecondMoneyThingParserTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-public class MoneyThingParserTest {
+public class SecondMoneyThingParserTest {
 
     private MoneyThingParser subject;
     private MobArena plugin;
@@ -26,31 +26,28 @@ public class MoneyThingParserTest {
     public void setup() {
         plugin = mock(MobArena.class);
         Economy economy = mock(Economy.class);
-        when(plugin.getEconomy()).thenReturn(economy);
 
         subject = new MoneyThingParser(plugin);
     }
 
-
     @Test
-    public void shortPrefix() {
-        MoneyThing result = subject.parse("$500");
+    public void noPrefixNoBenjamins() {
+        MoneyThing result = subject.parse("500");
 
-        assertThat(result, not(nullValue()));
-    }
-
-    @Test
-    public void longPrefix() {
-        MoneyThing result = subject.parse("money:500");
-
-        assertThat(result, not(nullValue()));
+        assertThat(result, is(nullValue()));
     }
 
 
     @Test
-    public void numberFormatForNaughtyValues() {
-        exception.expect(NumberFormatException.class);
-        subject.parse("$cash");
+    public void nullEconomyNullMoney() {
+        Logger logger = mock(Logger.class);
+        when(plugin.getEconomy()).thenReturn(null);
+        when(plugin.getLogger()).thenReturn(logger);
+
+        subject.parse("$500");
+
+        verify(logger).severe(anyString());
     }
+
 
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [X] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Duplicated the content of`MoneyThingParserTest.java` to `SecondMoneyThingParserTest.java` and removed the unnecessary stubbing `when(plugin.getEconomy()).thenReturn(economy)` in the setUp method, move the tests that do not execute the stubbing from `MoneyThingParserTest` to `SecondMoneyThingParserTest`

# Problem
Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_):


# Solution
Because the unnecessary stubbing `when(plugin.getEconomy()).thenReturn(economy)` exists in the `setUp` method, which will be executed before each test, we cannot duplicate the `setUp` method. To safely remove the unnecessary stubbing, we duplicated the test class, removed the unnecessary stubbing from the `setUp` method, and moved the two tests `noPrefixNoBenjamins` and `nullEconomyNullMoney` from the  `MoneyThingParserTest` class to `SecondMoneyThingParserTest` class.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->