### PR TITLE
Remove 2 unnecessary stubbings from RendersTemplateTest.java

### DIFF
--- a/src/test/java/com/garbagemule/MobArena/signs/RendersTemplateTest.java
+++ b/src/test/java/com/garbagemule/MobArena/signs/RendersTemplateTest.java
@@ -28,7 +28,7 @@ public class RendersTemplateTest {
     @Test
     public void rendersArenaName() {
         String name = "castle";
-        Arena arena = arena(name, false, false);
+        Arena arena = arena3(name, false, false);
         Template template = new Template.Builder("template")
             .withBase(new String[]{"<arena-name>", "", "", ""})
             .build();
@@ -41,7 +41,7 @@ public class RendersTemplateTest {
 
     @Test
     public void defaultsToBaseIfArenaIsNotRunning() {
-        Arena arena = arena("castle", false, false);
+        Arena arena = arena3("castle", false, false);
         String[] base = {"this", "is", "the", "base"};
         Template template = new Template.Builder("template")
             .withBase(base)
@@ -55,7 +55,7 @@ public class RendersTemplateTest {
 
     @Test
     public void idleOverridesBaseIfNotRunning() {
-        Arena arena = arena("castle", false, false);
+        Arena arena = arena3("castle", false, false);
         String[] idle = {"relax", "don't", "do", "it"};
         Template template = new Template.Builder("template")
             .withBase(new String[]{"this", "is", "the", "base"})
@@ -69,7 +69,7 @@ public class RendersTemplateTest {
 
     @Test
     public void runningOverridesBaseIfArenaIsRunning() {
-        Arena arena = arena("castle", true, false);
+        Arena arena = arena2("castle", true, false);
         String[] running = {"here", "is", "running", "yo"};
         Template template = new Template.Builder("template")
             .withBase(new String[]{"this", "is", "the", "base"})
@@ -83,7 +83,7 @@ public class RendersTemplateTest {
 
     @Test
     public void lobbyOverridesBaseIfPlayersInLobby() {
-        Arena arena = arena("castle", false, true);
+        Arena arena = arena3("castle", false, true);
         String[] joining = {"we", "in", "da", "lobby"};
         Template template = new Template.Builder("template")
             .withBase(new String[]{"this", "is", "the", "base"})
@@ -159,7 +159,7 @@ public class RendersTemplateTest {
 
     @Test
     public void doesNotRenderInvalidListEntries() {
-        Arena arena = arena("castle", false, true);
+        Arena arena = arena3("castle", false, true);
         String[] base = new String[]{"<ready-0>", "<ready--1>", "<ready-n>", "<ready-999999>"};
         Template template = new Template.Builder("template")
             .withBase(base)
@@ -179,4 +179,19 @@ public class RendersTemplateTest {
         return arena;
     }
 
+    private Arena arena2(String name, boolean running, boolean lobby) {
+        Arena arena = mock(Arena.class);
+        when(arena.configName()).thenReturn(name);
+        when(arena.isRunning()).thenReturn(running);
+        when(arena.getWaveManager()).thenReturn(mock(WaveManager.class));
+        return arena;
+    }
+
+    private Arena arena3(String name, boolean running, boolean lobby) {
+        Arena arena = mock(Arena.class);
+        when(arena.configName()).thenReturn(name);
+        when(arena.isRunning()).thenReturn(running);
+        when(arena.getPlayersInLobby()).thenReturn(lobby ? Collections.singleton(null) : Collections.emptySet());
+        return arena;
+    }
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [X] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Duplicated `arena()` method to `arena2()` and `arena3()` and removed the unnecessary stubbing from the duplicated methods, then applied `arena2()` to `RendersTemplateTest.runningOverridesBaseIfArenaIsRunning` and applied `arena3()` to `RendersTemplateTest.rendersArenaName`, `RendersTemplateTest.defaultsToBaseIfArenaIsNotRunning`, `RendersTemplateTest.idleOverridesBaseIfNotRunning`, `RendersTemplateTest.lobbyOverridesBaseIfPlayersInLobby`, `RendersTemplateTest.doesNotRenderInvalidListEntries`.


# Problem
Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_):


# Solution
The unnecessary stubbing which stubbed the `getPlayersInLobby()` method in `RendersTemplateTest.arena` is created but is not executed by the test `RendersTemplateTest.runningOverridesBaseIfArenaIsRunning` and the unnecessary stubbing which stubbed the `getWaveManager()` method in `RendersTemplateTest.arena` is created but is not executed by 5 tests: `RendersTemplateTest.rendersArenaName`, `RendersTemplateTest.defaultsToBaseIfArenaIsNotRunning`, `RendersTemplateTest.idleOverridesBaseIfNotRunning`, `RendersTemplateTest.lobbyOverridesBaseIfPlayersInLobby`, `RendersTemplateTest.doesNotRenderInvalidListEntries`. To safely remove the unnecessary stubbings,  we duplicated the `arena()` method, removed the unnecessary stubbing from the new duplicated methods, and applied new methods to the tests that did not execute the stubbings. 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->